### PR TITLE
added automatic downloading of ttf font, LD_LIBRARY_PATH wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+asteroids/result

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Classic games recreated in netwire
 ###Download and Install Nix, Alternatively install NixOS
 http://nixos.org/nix/download.html
 
-* Install nix
+#####Install nix
 ```bash
 #subscribe to nixpkgs-unstable channel
 nix-channel --add http://nixos.org/channels/nixpkgs-unstable

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@ netwire-classics
 
 Classic games recreated in netwire
 
-###Download and Install Nix, Alternatively install NixOS
+### Download and Install Nix
+
+https://www.domenkozar.com/2014/01/02/getting-started-with-nix-package-manager/
+https://gist.github.com/iElectric/8217950 - Nix install script
+
+### Alternatively install NixOS
+
 http://nixos.org/nix/download.html
 
 #####Install nix

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+netwire-classics
+================
+
+Classic games recreated in netwire
+
+###Download and Install Nix, Alternatively install NixOS
+http://nixos.org/nix/download.html
+
+* Install nix
+```bash
+#subscribe to nixpkgs-unstable channel
+nix-channel --add http://nixos.org/channels/nixpkgs-unstable
+#download current nix expressions
+nix-channel --update
+#update packages of user profile from downoaded nix expressions
+nix-env -u '*'
+```
+
+###Compile netwire-classics using Nix
+
+To compile add required LICENSE file to asteroids folder.
+Then in the netwire-classics folder run:
+```bash
+nix-build
+```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Classic games recreated in netwire
 ### Download and Install Nix
 
 https://www.domenkozar.com/2014/01/02/getting-started-with-nix-package-manager/
+
 https://gist.github.com/iElectric/8217950 - Nix install script
 
 ### Alternatively install NixOS

--- a/asteroids/Asteroids.hs
+++ b/asteroids/Asteroids.hs
@@ -15,6 +15,7 @@ import Control.Lens hiding (at, perform, wrapped)
 import Control.Wire hiding (until)
 import Data.Foldable
 import Data.Monoid
+import Paths_asteroids (getDataFileName)
 import Linear hiding ((*!))
 import qualified Data.Set as Set
 import qualified Graphics.UI.SDL as SDL
@@ -168,8 +169,8 @@ main = SDL.withInit [SDL.InitEverything] $ do
   screen <- SDL.setVideoMode 800 600 0 [SDL.SWSurface]--, SDL.Fullscreen]
 
   SDLTTF.init
-  ka1 <- SDLTTF.openFont "ka1.ttf" 10
-
+  ttfFilePath <- getDataFileName "fonts/beams-font/Beams.ttf"
+  ka1 <- SDLTTF.openFont ttfFilePath 10
   frameRate <- Framerate.new
   Framerate.init frameRate
   Framerate.set frameRate 120

--- a/asteroids/default.nix
+++ b/asteroids/default.nix
@@ -50,10 +50,41 @@ let
   };
 });
 
+
+beams = stdenv.mkDerivation {
+  name = "beams-font";
+  src = fetchurl {
+    url = http://openfontlibrary.org/assets/downloads/beams/e9dbb80c1c925d7676b2032afef1c01b/beams.zip;
+    sha256 = "697e38f7d6e3542572d747b1796b0ebf0702e86f75b258f602230a310736e09e";
+  };
+  
+  meta = {
+    description = "The beams font from openfontlibrary";
+  };
+  
+  buildInputs = [ unzip ]; 
+  
+  buildCommand = ''
+    mkdir -p $out
+    cd $out
+    unzip $src
+  '';
+};
+ 
+
 in cabal.mkDerivation (self: {
   pname = "netwire-classics";
   version = "0.1.0.0";
   src = ./.;
-  buildDepends = [ cabalInstall netwire SDL SDLMixer lens linear SDLgfx SDLttf
-  async ];
+  buildDepends = [ cabalInstall netwire SDL SDLMixer lens linear SDLgfx SDLttf async makeWrapper unzip beams ];
+  
+  isLibrary = false;
+  isExecutable = true;
+  
+  postInstall = ''
+    ensureDir "$out/share/asteroids-$version/fonts/"
+    ln -s ${beams} $out/share/asteroids-$version/fonts/${beams.name}
+    wrapProgram $out/bin/asteroids --prefix LD_LIBRARY_PATH : ${self.stdenv.gcc.gcc}/lib
+  ''; 
+  
 })


### PR DESCRIPTION
Hi,
I am trying to learn Haskell, and I wanted a simple game to learn with so I have been playing with your asteroids implementation after seeing your post about it on Reddit (hope you dont mind).  And since seeing your build setup I am now learning Nix too.

I ended up modifying default.nix to autodownload, unzip, and save a .ttf file from openfontlibrary.org to the /nix/store. The font is then symlinked to ./result/shared/fonts and an additional dependency system-filepath is then used to locate the .ttf file and use it with the asteroids project.  This font is not as good-looking, but it definitely has an open license, and picking a different one from openfontlibrary (or elsewhere) is about as simple as copying a link now.

When I built the program (under NixOS) it couldn't find the gcc library files, so I ended up using Nix's makeWrapper to allow me to attach the needed LD_LIBRARY_PATH env variable to the output.

I also found I had to point the src at the asteroids directory or it would not build when I ran "nix-build", are you using a different command to build?

Chris
